### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
     env_file: .env
     restart: always
     command: "python3 -m artemis.modules.karton_ssl_checks"
+    profiles: [x86]
 
   autoreporter:
     volumes:


### PR DESCRIPTION
in follow up with https://github.com/CERT-Polska/Artemis/pull/1021#issue-2316232234.

- adds the profile of x86 to it, which only runs the container if the architecture is not ARM